### PR TITLE
fix(lambda): missing Function URL should be empty, not 500; prefix GET hooks with /aws

### DIFF
--- a/src/backend/routes/aws/lambda.test.ts
+++ b/src/backend/routes/aws/lambda.test.ts
@@ -660,6 +660,29 @@ describe("Function URLs", () => {
     expect(body.authType).toBe("NONE");
   });
 
+  it("GET /functions/:name/url — empty when no URL config", async () => {
+    mockSend.mockRejectedValueOnce(
+      Object.assign(new Error("Function URL config not found"), {
+        name: "ResourceNotFoundException",
+      })
+    );
+    const res = await get("/functions/my-func/url");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      url: null,
+      authType: null,
+      cors: null,
+      invokeMode: null,
+    });
+  });
+
+  it("GET /functions/:name/url — rethrows unexpected errors as 500", async () => {
+    mockSend.mockRejectedValueOnce(new Error("boom"));
+    const res = await get("/functions/my-func/url");
+    expect(res.status).toBe(500);
+  });
+
   it("POST /functions/:name/url — creates URL config", async () => {
     mockSend.mockResolvedValueOnce({
       FunctionUrl: "https://example.com/fn",

--- a/src/backend/routes/aws/lambda.ts
+++ b/src/backend/routes/aws/lambda.ts
@@ -503,15 +503,28 @@ router.delete("/tags/:arn", async (c: Context) => {
 
 router.get("/functions/:name/url", async (c: Context) => {
   const name = c.req.param("name");
-  const result = await lambda().send(
-    new GetFunctionUrlConfigCommand({ FunctionName: name })
-  );
-  return c.json({
-    url: result.FunctionUrl,
-    authType: result.AuthType,
-    cors: result.Cors,
-    invokeMode: result.InvokeMode,
-  });
+  try {
+    const result = await lambda().send(
+      new GetFunctionUrlConfigCommand({ FunctionName: name })
+    );
+    return c.json({
+      url: result.FunctionUrl,
+      authType: result.AuthType,
+      cors: result.Cors,
+      invokeMode: result.InvokeMode,
+    });
+  } catch (e: any) {
+    // Most functions have no URL — surface as empty, not an error
+    if (e?.name === "ResourceNotFoundException") {
+      return c.json({
+        url: null,
+        authType: null,
+        cors: null,
+        invokeMode: null,
+      });
+    }
+    throw e;
+  }
 });
 
 router.delete("/functions/:name/url", async (c: Context) => {

--- a/src/frontend/hooks/useLambda.test.ts
+++ b/src/frontend/hooks/useLambda.test.ts
@@ -68,7 +68,7 @@ describe("useLambdaFunctions", () => {
     mockApi.mockResolvedValueOnce({ functions: [], total: 0 });
     const { result } = renderHook(() => useLambdaFunctions(), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi).toHaveBeenCalledWith("/lambda/functions");
+    expect(mockApi).toHaveBeenCalledWith("/aws/lambda/functions");
   });
 });
 
@@ -84,7 +84,7 @@ describe("useLambdaFunction", () => {
       wrapper: createWrapper(),
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi).toHaveBeenCalledWith("/lambda/functions/fn-1");
+    expect(mockApi).toHaveBeenCalledWith("/aws/lambda/functions/fn-1");
   });
 });
 
@@ -162,7 +162,7 @@ describe("useLambdaVersions", () => {
       wrapper: createWrapper(),
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi).toHaveBeenCalledWith("/lambda/functions/fn-1/versions");
+    expect(mockApi).toHaveBeenCalledWith("/aws/lambda/functions/fn-1/versions");
   });
 });
 
@@ -208,7 +208,7 @@ describe("useLambdaAliases", () => {
       wrapper: createWrapper(),
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi).toHaveBeenCalledWith("/lambda/functions/fn-1/aliases");
+    expect(mockApi).toHaveBeenCalledWith("/aws/lambda/functions/fn-1/aliases");
   });
 });
 
@@ -219,7 +219,7 @@ describe("useEventSourceMappings", () => {
     mockApi.mockResolvedValueOnce({ eventSourceMappings: [], total: 0 });
     const { result } = renderHook(() => useEventSourceMappings(), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi).toHaveBeenCalledWith("/lambda/event-source-mappings");
+    expect(mockApi).toHaveBeenCalledWith("/aws/lambda/event-source-mappings");
   });
 
   it("appends functionName when provided", async () => {
@@ -229,7 +229,7 @@ describe("useEventSourceMappings", () => {
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(mockApi).toHaveBeenCalledWith(
-      "/lambda/event-source-mappings?functionName=fn-1"
+      "/aws/lambda/event-source-mappings?functionName=fn-1"
     );
   });
 });
@@ -386,7 +386,7 @@ describe("useLambdaLayers", () => {
     mockApi.mockResolvedValueOnce({ layers: [], total: 0 });
     const { result } = renderHook(() => useLambdaLayers(), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi).toHaveBeenCalledWith("/lambda/layers");
+    expect(mockApi).toHaveBeenCalledWith("/aws/lambda/layers");
   });
 });
 
@@ -402,7 +402,7 @@ describe("useLambdaLayerVersions", () => {
       wrapper: createWrapper(),
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi).toHaveBeenCalledWith("/lambda/layers/layer-1/versions");
+    expect(mockApi).toHaveBeenCalledWith("/aws/lambda/layers/layer-1/versions");
   });
 });
 
@@ -433,7 +433,7 @@ describe("useLambdaTags", () => {
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(mockApi).toHaveBeenCalledWith(
-      "/lambda/tags/arn:aws:lambda:us-east-1:1:function:fn-1"
+      "/aws/lambda/tags/arn:aws:lambda:us-east-1:1:function:fn-1"
     );
   });
 });
@@ -450,7 +450,7 @@ describe("useFunctionUrl", () => {
     mockApi.mockResolvedValueOnce({ url: "https://x", authType: "NONE", cors: {}, invokeMode: "BUFFERED" });
     const { result } = renderHook(() => useFunctionUrl("fn-1"), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi).toHaveBeenCalledWith("/lambda/functions/fn-1/url");
+    expect(mockApi).toHaveBeenCalledWith("/aws/lambda/functions/fn-1/url");
   });
 });
 
@@ -468,7 +468,7 @@ describe("useFunctionConcurrency", () => {
       wrapper: createWrapper(),
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi).toHaveBeenCalledWith("/lambda/functions/fn-1/concurrency");
+    expect(mockApi).toHaveBeenCalledWith("/aws/lambda/functions/fn-1/concurrency");
   });
 });
 
@@ -557,7 +557,7 @@ describe("useEventInvokeConfig", () => {
       wrapper: createWrapper(),
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi).toHaveBeenCalledWith("/lambda/functions/fn-1/event-invoke-config");
+    expect(mockApi).toHaveBeenCalledWith("/aws/lambda/functions/fn-1/event-invoke-config");
   });
 });
 
@@ -620,7 +620,7 @@ describe("useCodeSigningConfig", () => {
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(mockApi).toHaveBeenCalledWith(
-      "/lambda/functions/fn-1/code-signing-config"
+      "/aws/lambda/functions/fn-1/code-signing-config"
     );
   });
 });
@@ -697,7 +697,7 @@ describe("useCodeSigningConfigs", () => {
       wrapper: createWrapper(),
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi).toHaveBeenCalledWith("/lambda/code-signing-configs");
+    expect(mockApi).toHaveBeenCalledWith("/aws/lambda/code-signing-configs");
   });
 });
 

--- a/src/frontend/hooks/useLambda.ts
+++ b/src/frontend/hooks/useLambda.ts
@@ -6,14 +6,14 @@ import { api } from "../lib/client";
 export function useLambdaFunctions() {
   return useQuery({
     queryKey: ["aws", "lambda", "functions"],
-    queryFn: () => api<{ functions: any[]; total: number }>("/lambda/functions"),
+    queryFn: () => api<{ functions: any[]; total: number }>("/aws/lambda/functions"),
   });
 }
 
 export function useLambdaFunction(name: string | null) {
   return useQuery({
     queryKey: ["aws", "lambda", "functions", name],
-    queryFn: () => api<{ configuration: any; code: any }>(`/lambda/functions/${name}`),
+    queryFn: () => api<{ configuration: any; code: any }>(`/aws/lambda/functions/${name}`),
     enabled: !!name,
   });
 }
@@ -61,7 +61,7 @@ export function useInvokeFunction() {
 export function useLambdaVersions(name: string | null) {
   return useQuery({
     queryKey: ["aws", "lambda", "functions", name, "versions"],
-    queryFn: () => api<{ versions: any[]; total: number }>(`/lambda/functions/${name}/versions`),
+    queryFn: () => api<{ versions: any[]; total: number }>(`/aws/lambda/functions/${name}/versions`),
     enabled: !!name,
   });
 }
@@ -80,7 +80,7 @@ export function usePublishVersion() {
 export function useLambdaAliases(name: string | null) {
   return useQuery({
     queryKey: ["aws", "lambda", "functions", name, "aliases"],
-    queryFn: () => api<{ aliases: any[]; total: number }>(`/lambda/functions/${name}/aliases`),
+    queryFn: () => api<{ aliases: any[]; total: number }>(`/aws/lambda/functions/${name}/aliases`),
     enabled: !!name,
   });
 }
@@ -92,7 +92,7 @@ export function useEventSourceMappings(functionName?: string) {
     queryKey: ["aws", "lambda", "event-source-mappings", functionName],
     queryFn: () =>
       api<{ eventSourceMappings: any[]; total: number }>(
-        `/lambda/event-source-mappings${functionName ? `?functionName=${functionName}` : ""}`
+        `/aws/lambda/event-source-mappings${functionName ? `?functionName=${functionName}` : ""}`
       ),
   });
 }
@@ -220,14 +220,14 @@ export function useUpdateLambdaAlias(name: string) {
 export function useLambdaLayers() {
   return useQuery({
     queryKey: ["aws", "lambda", "layers"],
-    queryFn: () => api<{ layers: any[]; total: number }>("/lambda/layers"),
+    queryFn: () => api<{ layers: any[]; total: number }>("/aws/lambda/layers"),
   });
 }
 
 export function useLambdaLayerVersions(name: string | null) {
   return useQuery({
     queryKey: ["aws", "lambda", "layers", name, "versions"],
-    queryFn: () => api<{ versions: any[]; total: number }>(`/lambda/layers/${name}/versions`),
+    queryFn: () => api<{ versions: any[]; total: number }>(`/aws/lambda/layers/${name}/versions`),
     enabled: !!name,
   });
 }
@@ -248,7 +248,7 @@ export function useDeleteLayerVersion() {
 export function useLambdaTags(arn: string | null) {
   return useQuery({
     queryKey: ["aws", "lambda", "tags", arn],
-    queryFn: () => api<{ tags: Record<string, string> }>(`/lambda/tags/${arn}`),
+    queryFn: () => api<{ tags: Record<string, string> }>(`/aws/lambda/tags/${arn}`),
     enabled: !!arn,
   });
 }
@@ -258,7 +258,7 @@ export function useLambdaTags(arn: string | null) {
 export function useFunctionUrl(name: string | null) {
   return useQuery({
     queryKey: ["aws", "lambda", "functions", name, "url"],
-    queryFn: () => api<{ url: string; authType: string; cors: any; invokeMode: string }>(`/lambda/functions/${name}/url`),
+    queryFn: () => api<{ url: string | null; authType: string | null; cors: any; invokeMode: string | null }>(`/aws/lambda/functions/${name}/url`),
     enabled: !!name,
   });
 }
@@ -298,7 +298,7 @@ export function useUpdateFunctionUrl() {
 export function useFunctionConcurrency(name: string | null) {
   return useQuery({
     queryKey: ["aws", "lambda", "functions", name, "concurrency"],
-    queryFn: () => api<{ reservedConcurrentExecutions: number | undefined }>(`/lambda/functions/${name}/concurrency`),
+    queryFn: () => api<{ reservedConcurrentExecutions: number | undefined }>(`/aws/lambda/functions/${name}/concurrency`),
     enabled: !!name,
   });
 }
@@ -333,7 +333,7 @@ export function useEventInvokeConfig(name: string | null) {
     queryKey: ["aws", "lambda", "functions", name, "event-invoke-config"],
     queryFn: () =>
       api<{ maximumRetryAttempts?: number; maximumEventAgeInSeconds?: number; destinationConfig?: any; functionArn?: string }>(
-        `/lambda/functions/${name}/event-invoke-config`
+        `/aws/lambda/functions/${name}/event-invoke-config`
       ),
     enabled: !!name,
   });
@@ -382,7 +382,7 @@ export function useCodeSigningConfig(name: string | null) {
     queryKey: ["aws", "lambda", "functions", name, "code-signing-config"],
     queryFn: () =>
       api<{ codeSigningConfigArn?: string; functionName?: string }>(
-        `/lambda/functions/${name}/code-signing-config`
+        `/aws/lambda/functions/${name}/code-signing-config`
       ),
     enabled: !!name,
   });
@@ -415,7 +415,7 @@ export function useCodeSigningConfigs() {
   return useQuery({
     queryKey: ["aws", "lambda", "code-signing-configs"],
     queryFn: () =>
-      api<{ codeSigningConfigs: any[]; total: number }>("/lambda/code-signing-configs"),
+      api<{ codeSigningConfigs: any[]; total: number }>("/aws/lambda/code-signing-configs"),
   });
 }
 


### PR DESCRIPTION
## Summary
- Closes https://github.com/ofsazib/floci-dash/issues/6 — Floci (and AWS) return `ResourceNotFoundException` from `GetFunctionUrlConfig` when a function has no Function URL. That is correct. The dash GET `/functions/:name/url` handler had no catch, so the SDK throw became HTTP 500 and the frontend `api()` toast fired on every function detail page. Policy GET already maps the same exception to an empty payload; URL GET now does the same (`url`/`authType`/`cors`/`invokeMode` null). The UI already renders "No URL configured" when `url` is falsy.
- Closes https://github.com/ofsazib/floci-dash/issues/5 — Lambda **GET** hooks were calling `/lambda/...` while mutations (and every other service) use `/aws/lambda/...`. The backend is mounted at `/api/aws/lambda`. Unknown `/api/*` paths return the SPA HTML with status 200, so `JSON.parse` threw `Unexpected token '<'` and the function list stayed empty.

This is a **dashboard** bug, not a Floci emulator bug.

Fixes #5
Fixes #6

## Test plan
- [x] Unit: `GET /functions/:name/url` returns 200 with nulls on `ResourceNotFoundException`
- [x] Unit: unexpected errors on that route still return 500
- [x] Unit: Lambda GET hooks call `/aws/lambda/...`
- [x] `pnpm typecheck` passes
- [ ] After merge/image bump: open Lambda list, then a function with no URL — list populated, no 500 toast, "No URL configured"