### PR TITLE
Feat/cloudwatch log filter search

### DIFF
--- a/src/frontend/hooks/useLogs.test.ts
+++ b/src/frontend/hooks/useLogs.test.ts
@@ -21,7 +21,7 @@ import {
   useDeleteLogStream,
   useLogEvents,
   usePutLogEvents,
-  useFilterLogEvents,
+  useFilteredLogEvents,
   useSubscriptionFilters,
   usePutSubscriptionFilter,
   useDeleteSubscriptionFilter,
@@ -321,18 +321,68 @@ describe("usePutLogEvents", () => {
   });
 });
 
-describe("useFilterLogEvents", () => {
-  it("calls api with POST method, encoded group in path, filter body", async () => {
+describe("useFilteredLogEvents", () => {
+  it("does NOT call api when filterPattern is empty", () => {
+    renderHook(
+      () => useFilteredLogEvents("/aws/lambda/test", "my-stream", { filterPattern: "" }),
+      { wrapper: createWrapper() }
+    );
+    expect(mockApi).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call api when logStreamName is null", () => {
+    renderHook(
+      () => useFilteredLogEvents("/aws/lambda/test", null, { filterPattern: "ERROR" }),
+      { wrapper: createWrapper() }
+    );
+    expect(mockApi).not.toHaveBeenCalled();
+  });
+
+  it("POSTs to filter-events, scopes to the stream, and computes startTime from offset", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
     mockApi.mockResolvedValueOnce({ events: [] });
-    const { result } = renderHook(() => useFilterLogEvents("/aws/lambda/test"), {
-      wrapper: createWrapper(),
-    });
-    await result.current.mutateAsync({ filterPattern: "ERROR", limit: 10 });
+    const { result } = renderHook(
+      () =>
+        useFilteredLogEvents("/aws/lambda/test", "my-stream", {
+          filterPattern: "ERROR",
+          startTimeOffsetMs: 3_600_000,
+          limit: 100,
+        }),
+      { wrapper: createWrapper() }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(mockApi).toHaveBeenCalledWith(
       `/aws/logs/log-groups/${encodeURIComponent("/aws/lambda/test")}/filter-events`,
       expect.objectContaining({
         method: "POST",
-        body: JSON.stringify({ filterPattern: "ERROR", limit: 10 }),
+        body: JSON.stringify({
+          filterPattern: "ERROR",
+          logStreamNames: ["my-stream"],
+          startTime: now - 3_600_000,
+          limit: 100,
+        }),
+      })
+    );
+  });
+
+  it("omits startTime when no offset is given (All time)", async () => {
+    mockApi.mockResolvedValueOnce({ events: [] });
+    const { result } = renderHook(
+      () =>
+        useFilteredLogEvents("/g", "s", { filterPattern: "ERROR", limit: 50 }),
+      { wrapper: createWrapper() }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi).toHaveBeenCalledWith(
+      `/aws/logs/log-groups/${encodeURIComponent("/g")}/filter-events`,
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          filterPattern: "ERROR",
+          logStreamNames: ["s"],
+          limit: 50,
+        }),
       })
     );
   });

--- a/src/frontend/hooks/useLogs.test.ts
+++ b/src/frontend/hooks/useLogs.test.ts
@@ -386,6 +386,35 @@ describe("useFilteredLogEvents", () => {
       })
     );
   });
+
+  it("omits limit when none is given", async () => {
+    mockApi.mockResolvedValueOnce({ events: [] });
+    const { result } = renderHook(
+      () => useFilteredLogEvents("/g", "s", { filterPattern: "ERROR" }),
+      { wrapper: createWrapper() }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi).toHaveBeenCalledWith(
+      `/aws/logs/log-groups/${encodeURIComponent("/g")}/filter-events`,
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          filterPattern: "ERROR",
+          logStreamNames: ["s"],
+        }),
+      })
+    );
+  });
+
+  it("disables polling when autoRefresh is false", async () => {
+    mockApi.mockResolvedValueOnce({ events: [] });
+    const { result } = renderHook(
+      () => useFilteredLogEvents("/g", "s", { filterPattern: "ERROR" }, false),
+      { wrapper: createWrapper() }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ─── Subscription Filter Hooks ────────────────────────

--- a/src/frontend/hooks/useLogs.ts
+++ b/src/frontend/hooks/useLogs.ts
@@ -282,19 +282,59 @@ export function usePutLogEvents() {
 
 // ─── Filter Log Events ────────────────────────────────
 
-export function useFilterLogEvents(logGroupName: string | null) {
-  return useMutation({
-    mutationFn: (data: {
-      filterPattern?: string;
-      startTime?: number;
-      endTime?: number;
-      limit?: number;
-      logStreamNames?: string[];
-    }) =>
-      api(`/aws/logs/log-groups/${encodeURIComponent(logGroupName!)}/filter-events`, {
-        method: "POST",
-        body: JSON.stringify(data),
-      }),
+/**
+ * Search a single log stream with a CloudWatch filter pattern via FilterLogEvents.
+ *
+ * `startTimeOffsetMs` is a window size relative to "now" (e.g. 3_600_000 for the last
+ * hour); the absolute `startTime` is recomputed on every fetch so the window tracks the
+ * present time across auto-refresh ticks. Omit it to search all time. The query is only
+ * enabled once a log group, stream, and non-empty filter pattern are all present.
+ */
+export function useFilteredLogEvents(
+  logGroupName: string | null,
+  logStreamName: string | null,
+  options: {
+    filterPattern?: string;
+    startTimeOffsetMs?: number;
+    limit?: number;
+  },
+  autoRefresh?: boolean
+) {
+  return useQuery<FilteredLogEventsResponse>({
+    queryKey: [
+      "aws",
+      "logs",
+      "log-groups",
+      logGroupName,
+      "streams",
+      logStreamName,
+      "filter-events",
+      options,
+    ],
+    queryFn: () => {
+      const body: {
+        filterPattern?: string;
+        logStreamNames: string[];
+        startTime?: number;
+        limit?: number;
+      } = {
+        filterPattern: options.filterPattern,
+        logStreamNames: [logStreamName!],
+      };
+      if (options.startTimeOffsetMs) {
+        body.startTime = Date.now() - options.startTimeOffsetMs;
+      }
+      if (options.limit) body.limit = options.limit;
+      return api(
+        `/aws/logs/log-groups/${encodeURIComponent(logGroupName!)}/filter-events`,
+        {
+          method: "POST",
+          body: JSON.stringify(body),
+        }
+      );
+    },
+    enabled: !!logGroupName && !!logStreamName && !!options.filterPattern,
+    refetchInterval: autoRefresh !== false ? 5000 : false,
   });
 }
 

--- a/src/frontend/pages/services/CloudWatchLogsDashboard.test.tsx
+++ b/src/frontend/pages/services/CloudWatchLogsDashboard.test.tsx
@@ -67,6 +67,7 @@ const mockLogStreams = vi.fn();
 const mockCreateStream = vi.fn();
 const mockDeleteStream = vi.fn();
 const mockLogEvents = vi.fn();
+const mockFilteredLogEvents = vi.fn();
 const mockPutRetention = vi.fn();
 const mockDeleteRetention = vi.fn();
 const mockSubFilters = vi.fn();
@@ -104,6 +105,7 @@ vi.mock("../../hooks/useLogs", () => ({
     get variables() { return deleteStreamState.variables; },
   }),
   useLogEvents: (...args: any[]) => mockLogEvents(...args),
+  useFilteredLogEvents: (...args: any[]) => mockFilteredLogEvents(...args),
   usePutRetentionPolicy: () => ({
     mutate: mockPutRetention,
     get isPending() { return putRetentionState.isPending; },
@@ -188,6 +190,7 @@ beforeEach(() => {
   mockLogGroups.mockReturnValue({ data: { logGroups: [], total: 0 }, isLoading: false, isError: false, error: null });
   mockLogStreams.mockReturnValue({ data: { logStreams: [], total: 0 }, isLoading: false, isError: false, error: null });
   mockLogEvents.mockReturnValue({ data: { events: [] }, isLoading: false, isError: false, error: null, refetch: vi.fn() });
+  mockFilteredLogEvents.mockReturnValue({ data: { events: [] }, isLoading: false, isError: false, error: null, refetch: vi.fn() });
   mockSubFilters.mockReturnValue({ data: { subscriptionFilters: [], total: 0 }, isLoading: false, isError: false, error: null });
   mockTags.mockReturnValue({ data: { tags: {} }, isLoading: false, isError: false, error: null });
 });
@@ -1690,6 +1693,85 @@ describe("CloudWatchLogsDashboard", () => {
     await user.click(screen.getAllByRole("option", { name: /Never expire/i })[0]);
     await clickButton(user, /Save retention/i);
     await waitFor(() => expect(mockDeleteRetention).toHaveBeenCalledWith("/aws/lambda/test"));
+  });
+
+  // ── Filter-pattern search (single stream) ───────────────
+
+  async function gotoStream(user: ReturnType<typeof userEvent.setup>) {
+    mockLogGroups.mockReturnValue({
+      data: { logGroups: [{ logGroupName: "/aws/lambda/test" }], total: 1 },
+      isLoading: false, isError: false, error: null,
+    });
+    mockLogStreams.mockReturnValue({
+      data: { logStreams: [{ logStreamName: "my-stream", storedBytes: 512 }], total: 1 },
+      isLoading: false, isError: false, error: null,
+    });
+    render(<CloudWatchLogsDashboard />, { wrapper: createWrapper() });
+    await waitFor(() => screen.getByText("/aws/lambda/test"));
+    await user.click(screen.getByText("/aws/lambda/test"));
+    await waitFor(() => expect(screen.getByText("my-stream")).toBeTruthy());
+    await user.click(screen.getByText("my-stream"));
+    await waitFor(() => expect(screen.getByText(/Back to Log Streams/i)).toBeTruthy());
+  }
+
+  it("shows the filter-pattern search box in the stream viewer", async () => {
+    const user = userEvent.setup();
+    await gotoStream(user);
+    expect(screen.getByPlaceholderText(/ERROR/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^Search$/i })).toBeTruthy();
+  });
+
+  it("runs a filter-pattern search scoped to the current stream", async () => {
+    const user = userEvent.setup();
+    mockFilteredLogEvents.mockReturnValue({
+      data: { events: [{ eventId: "f1", timestamp: 1705000000000, message: "boom ERROR here" }] },
+      isLoading: false, isError: false, error: null, refetch: vi.fn(),
+    });
+    await gotoStream(user);
+    await user.type(screen.getByPlaceholderText(/ERROR/i), "ERROR");
+    await user.click(screen.getByRole("button", { name: /^Search$/i }));
+    await waitFor(() =>
+      expect(mockFilteredLogEvents).toHaveBeenLastCalledWith(
+        "/aws/lambda/test",
+        "my-stream",
+        expect.objectContaining({ filterPattern: "ERROR" }),
+        expect.anything()
+      )
+    );
+    expect(screen.getByText("boom ERROR here")).toBeTruthy();
+  });
+
+  it("shows a no-match empty state when a search returns nothing", async () => {
+    const user = userEvent.setup();
+    mockFilteredLogEvents.mockReturnValue({
+      data: { events: [] }, isLoading: false, isError: false, error: null, refetch: vi.fn(),
+    });
+    await gotoStream(user);
+    await user.type(screen.getByPlaceholderText(/ERROR/i), "NOPE");
+    await user.click(screen.getByRole("button", { name: /^Search$/i }));
+    await waitFor(() => expect(screen.getByText(/No events matched/i)).toBeTruthy());
+  });
+
+  it("clears the search and returns to live-tail mode", async () => {
+    const user = userEvent.setup();
+    await gotoStream(user);
+    await user.type(screen.getByPlaceholderText(/ERROR/i), "ERROR");
+    await user.click(screen.getByRole("button", { name: /^Search$/i }));
+    await waitFor(() =>
+      expect(mockFilteredLogEvents).toHaveBeenLastCalledWith(
+        "/aws/lambda/test", "my-stream",
+        expect.objectContaining({ filterPattern: "ERROR" }),
+        expect.anything()
+      )
+    );
+    await user.click(screen.getByRole("button", { name: /Clear/i }));
+    await waitFor(() =>
+      expect(mockFilteredLogEvents).toHaveBeenLastCalledWith(
+        "/aws/lambda/test", "my-stream",
+        expect.objectContaining({ filterPattern: "" }),
+        expect.anything()
+      )
+    );
   });
 });
 

--- a/src/frontend/pages/services/CloudWatchLogsDashboard.test.tsx
+++ b/src/frontend/pages/services/CloudWatchLogsDashboard.test.tsx
@@ -1778,6 +1778,44 @@ describe("CloudWatchLogsDashboard", () => {
       )
     );
   });
+
+  it("runs the search on Enter and ignores other keys", async () => {
+    const user = userEvent.setup();
+    await gotoStream(user);
+    const input = screen.getByLabelText("Filter pattern");
+    await user.type(input, "ERROR");
+    // A non-Enter key must not commit the filter.
+    await user.type(input, "{Escape}");
+    expect(mockFilteredLogEvents).not.toHaveBeenCalledWith(
+      "/aws/lambda/test", "my-stream",
+      expect.objectContaining({ filterPattern: "ERROR" }),
+      expect.anything()
+    );
+    await user.type(input, "{Enter}");
+    await waitFor(() =>
+      expect(mockFilteredLogEvents).toHaveBeenLastCalledWith(
+        "/aws/lambda/test", "my-stream",
+        expect.objectContaining({ filterPattern: "ERROR" }),
+        expect.anything()
+      )
+    );
+  });
+
+  it("drops the time window when the range is switched to All time", async () => {
+    const user = userEvent.setup();
+    await gotoStream(user);
+    await user.click(screen.getByRole("button", { name: /Time range/i }));
+    await user.click(screen.getAllByRole("option", { name: /All time/i })[0]);
+    await user.type(screen.getByLabelText("Filter pattern"), "ERROR");
+    await user.click(screen.getByRole("button", { name: /^Search$/i }));
+    await waitFor(() =>
+      expect(mockFilteredLogEvents).toHaveBeenLastCalledWith(
+        "/aws/lambda/test", "my-stream",
+        expect.objectContaining({ filterPattern: "ERROR", startTimeOffsetMs: undefined }),
+        expect.anything()
+      )
+    );
+  });
 });
 
 describe("CloudWatchLogsDashboard — Data Protection tab", () => {

--- a/src/frontend/pages/services/CloudWatchLogsDashboard.test.tsx
+++ b/src/frontend/pages/services/CloudWatchLogsDashboard.test.tsx
@@ -1717,8 +1717,10 @@ describe("CloudWatchLogsDashboard", () => {
   it("shows the filter-pattern search box in the stream viewer", async () => {
     const user = userEvent.setup();
     await gotoStream(user);
-    expect(screen.getByPlaceholderText(/ERROR/i)).toBeTruthy();
+    expect(screen.getByLabelText("Filter pattern")).toBeTruthy();
     expect(screen.getByRole("button", { name: /^Search$/i })).toBeTruthy();
+    // Hint reflects Floci's actual behaviour (case-sensitive substring match).
+    expect(screen.getByText(/case-sensitive/i)).toBeTruthy();
   });
 
   it("runs a filter-pattern search scoped to the current stream", async () => {
@@ -1728,7 +1730,7 @@ describe("CloudWatchLogsDashboard", () => {
       isLoading: false, isError: false, error: null, refetch: vi.fn(),
     });
     await gotoStream(user);
-    await user.type(screen.getByPlaceholderText(/ERROR/i), "ERROR");
+    await user.type(screen.getByLabelText("Filter pattern"), "ERROR");
     await user.click(screen.getByRole("button", { name: /^Search$/i }));
     await waitFor(() =>
       expect(mockFilteredLogEvents).toHaveBeenLastCalledWith(
@@ -1747,15 +1749,18 @@ describe("CloudWatchLogsDashboard", () => {
       data: { events: [] }, isLoading: false, isError: false, error: null, refetch: vi.fn(),
     });
     await gotoStream(user);
-    await user.type(screen.getByPlaceholderText(/ERROR/i), "NOPE");
+    await user.type(screen.getByLabelText("Filter pattern"), "NOPE");
     await user.click(screen.getByRole("button", { name: /^Search$/i }));
-    await waitFor(() => expect(screen.getByText(/No events matched/i)).toBeTruthy());
+    // Default window is "Last 1 hour" — the empty state should nudge widening it.
+    await waitFor(() =>
+      expect(screen.getByText(/No events matched .* widen the time range/i)).toBeTruthy()
+    );
   });
 
   it("clears the search and returns to live-tail mode", async () => {
     const user = userEvent.setup();
     await gotoStream(user);
-    await user.type(screen.getByPlaceholderText(/ERROR/i), "ERROR");
+    await user.type(screen.getByLabelText("Filter pattern"), "ERROR");
     await user.click(screen.getByRole("button", { name: /^Search$/i }));
     await waitFor(() =>
       expect(mockFilteredLogEvents).toHaveBeenLastCalledWith(

--- a/src/frontend/pages/services/CloudWatchLogsDashboard.tsx
+++ b/src/frontend/pages/services/CloudWatchLogsDashboard.tsx
@@ -1086,6 +1086,13 @@ function CloudWatchLogStreamDetail({
 
   const events = (activeData?.events || []).slice().reverse(); // newest first
 
+  // When a search returns nothing within a bounded window, the events may simply be
+  // older than the window (live-tail ignores time, so they can still show there).
+  // Nudge the user to widen the range rather than assume there's no match at all.
+  const searchEmptyMessage = startTimeOffsetMs
+    ? `No events matched this filter within ${timeRange.label} — widen the time range to search further back.`
+    : "No events matched this filter.";
+
   function handleSearch() {
     setAppliedFilter(filterInput.trim());
     setAutoScroll(false);
@@ -1162,7 +1169,7 @@ function CloudWatchLogStreamDetail({
                 onKeyDown={({ detail }) => {
                   if (detail.key === "Enter") handleSearch();
                 }}
-                placeholder={'Filter pattern — e.g. ?ERROR ?WARN  or  { $.level = "ERROR" }'}
+                placeholder={"Search log events — e.g. Application startup complete"}
                 ariaLabel="Filter pattern"
                 type="search"
               />
@@ -1184,8 +1191,8 @@ function CloudWatchLogStreamDetail({
           </div>
           <Box fontSize="body-s" color="text-body-secondary">
             {isSearchMode
-              ? `Searching this stream with a CloudWatch filter pattern (${timeRange.label}).`
-              : "Enter a CloudWatch filter pattern to search this stream. Term matching (ERROR), OR (?A ?B), and JSON ({ $.level = \"ERROR\" }) syntax are supported."}
+              ? `Searching this stream (${timeRange.label}) — case-sensitive substring match.`
+              : 'Case-sensitive substring match — type any word or phrase (e.g. Application startup complete). Floci matches the literal text; CloudWatch operators like ?A ?B and { $.level = "ERROR" } are not supported.'}
           </Box>
         </SpaceBetween>
       </Container>
@@ -1202,9 +1209,7 @@ function CloudWatchLogStreamDetail({
 
       {events.length === 0 && !isActiveLoading && !isActiveError && (
         <Box textAlign="center" padding="xl" color="text-body-secondary">
-          {isSearchMode
-            ? "No events matched this filter."
-            : "No log events found for this stream."}
+          {isSearchMode ? searchEmptyMessage : "No log events found for this stream."}
         </Box>
       )}
 

--- a/src/frontend/pages/services/CloudWatchLogsDashboard.tsx
+++ b/src/frontend/pages/services/CloudWatchLogsDashboard.tsx
@@ -48,6 +48,7 @@ import {
   useCreateLogStream,
   useDeleteLogStream,
   useLogEvents,
+  useFilteredLogEvents,
   usePutLogEvents,
   useSubscriptionFilters,
   usePutSubscriptionFilter,
@@ -1037,13 +1038,34 @@ function CloudWatchLogStreamDetail({
   const [autoRefresh, setAutoRefresh] = useState(true);
   const deleteLogStream = useDeleteLogStream();
 
+  // Filter-pattern search state. `filterInput` is the live text box; `appliedFilter`
+  // is the committed pattern that actually drives the search (set on Search / Enter,
+  // emptied on Clear). A non-empty applied filter switches the view into search mode.
+  const [filterInput, setFilterInput] = useState("");
+  const [appliedFilter, setAppliedFilter] = useState("");
+  const [timeRange, setTimeRange] = useState(TIME_RANGE_OPTIONS[2]); // Last 1 hour
+  const isSearchMode = appliedFilter.trim().length > 0;
+
+  const limitNum = parseInt((limit.value || "500") as string);
+  const startTimeOffsetMs =
+    timeRange.value && timeRange.value !== "0"
+      ? parseInt(timeRange.value as string)
+      : undefined;
+
   const { data, isLoading, isError, error, refetch } = useLogEvents(
     logGroupName,
     logStreamName,
     {
-      limit: parseInt(limit.value!),
+      limit: limitNum,
       startFromHead: false,
     },
+    autoRefresh && !isSearchMode
+  );
+
+  const filtered = useFilteredLogEvents(
+    logGroupName,
+    logStreamName,
+    { filterPattern: appliedFilter, startTimeOffsetMs, limit: limitNum },
     autoRefresh
   );
 
@@ -1051,13 +1073,28 @@ function CloudWatchLogStreamDetail({
   const eventsContainerRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
 
+  const activeData = isSearchMode ? filtered.data : data;
+  const activeError = isSearchMode ? filtered.error : error;
+  const isActiveError = isSearchMode ? filtered.isError : isError;
+  const isActiveLoading = isSearchMode ? filtered.isLoading : isLoading;
+
   useEffect(() => {
-    if (autoScroll && eventsContainerRef.current) {
+    if (autoScroll && !isSearchMode && eventsContainerRef.current) {
       eventsContainerRef.current.scrollTop = eventsContainerRef.current.scrollHeight;
     }
-  }, [data?.events, autoScroll]);
+  }, [activeData?.events, autoScroll, isSearchMode]);
 
-  const events = (data?.events || []).slice().reverse(); // newest first
+  const events = (activeData?.events || []).slice().reverse(); // newest first
+
+  function handleSearch() {
+    setAppliedFilter(filterInput.trim());
+    setAutoScroll(false);
+  }
+
+  function handleClearSearch() {
+    setFilterInput("");
+    setAppliedFilter("");
+  }
 
   return (
     <SpaceBetween size="l">
@@ -1115,19 +1152,59 @@ function CloudWatchLogStreamDetail({
         Log Events
       </Header>
 
-      {isError && (
+      <Container>
+        <SpaceBetween size="xs">
+          <div style={{ display: "flex", gap: "8px", alignItems: "flex-start" }}>
+            <div style={{ flex: 1 }}>
+              <Input
+                value={filterInput}
+                onChange={({ detail }) => setFilterInput(detail.value)}
+                onKeyDown={({ detail }) => {
+                  if (detail.key === "Enter") handleSearch();
+                }}
+                placeholder={'Filter pattern — e.g. ?ERROR ?WARN  or  { $.level = "ERROR" }'}
+                ariaLabel="Filter pattern"
+                type="search"
+              />
+            </div>
+            <Select
+              selectedOption={timeRange}
+              onChange={({ detail }) => setTimeRange(detail.selectedOption)}
+              options={TIME_RANGE_OPTIONS}
+              ariaLabel="Time range"
+            />
+            <Button variant="primary" onClick={handleSearch}>
+              Search
+            </Button>
+            {isSearchMode && (
+              <Button variant="normal" iconName="close" onClick={handleClearSearch}>
+                Clear
+              </Button>
+            )}
+          </div>
+          <Box fontSize="body-s" color="text-body-secondary">
+            {isSearchMode
+              ? `Searching this stream with a CloudWatch filter pattern (${timeRange.label}).`
+              : "Enter a CloudWatch filter pattern to search this stream. Term matching (ERROR), OR (?A ?B), and JSON ({ $.level = \"ERROR\" }) syntax are supported."}
+          </Box>
+        </SpaceBetween>
+      </Container>
+
+      {isActiveError && (
         <Alert type="error" dismissible>
-          {(error as Error)?.message || "Failed to load log events"}
+          {(activeError as Error)?.message || "Failed to load log events"}
         </Alert>
       )}
 
-      {isLoading && events.length === 0 && (
+      {isActiveLoading && events.length === 0 && (
         <StatusIndicator type="loading">Loading log events...</StatusIndicator>
       )}
 
-      {events.length === 0 && !isLoading && !isError && (
+      {events.length === 0 && !isActiveLoading && !isActiveError && (
         <Box textAlign="center" padding="xl" color="text-body-secondary">
-          No log events found for this stream.
+          {isSearchMode
+            ? "No events matched this filter."
+            : "No log events found for this stream."}
         </Box>
       )}
 
@@ -1185,11 +1262,11 @@ function CloudWatchLogStreamDetail({
         ))}
       </div>
 
-      {isLoading && events.length > 0 && (
+      {isActiveLoading && events.length > 0 && (
         <StatusIndicator type="loading">Refreshing events...</StatusIndicator>
       )}
 
-      {data && (
+      {activeData && (
         <Box textAlign="center" fontSize="body-s" color="text-body-secondary">
           {events.length} events displayed
         </Box>
@@ -1650,4 +1727,16 @@ const LOG_VIEW_LIMIT_OPTIONS: SelectProps.Option[] = [
   { label: "500", value: "500" },
   { label: "1000", value: "1000" },
   { label: "10000", value: "10000" },
+];
+
+// Relative time-range presets for filter-pattern search. `value` is the window size in
+// milliseconds; "0" means all time (no startTime bound).
+const TIME_RANGE_OPTIONS: SelectProps.Option[] = [
+  { label: "Last 5 minutes", value: String(5 * 60 * 1000) },
+  { label: "Last 15 minutes", value: String(15 * 60 * 1000) },
+  { label: "Last 1 hour", value: String(60 * 60 * 1000) },
+  { label: "Last 3 hours", value: String(3 * 60 * 60 * 1000) },
+  { label: "Last 12 hours", value: String(12 * 60 * 60 * 1000) },
+  { label: "Last 24 hours", value: String(24 * 60 * 60 * 1000) },
+  { label: "All time", value: "0" },
 ];

--- a/src/frontend/pages/services/CloudWatchLogsDashboard.tsx
+++ b/src/frontend/pages/services/CloudWatchLogsDashboard.tsx
@@ -1046,7 +1046,7 @@ function CloudWatchLogStreamDetail({
   const [timeRange, setTimeRange] = useState(TIME_RANGE_OPTIONS[2]); // Last 1 hour
   const isSearchMode = appliedFilter.trim().length > 0;
 
-  const limitNum = parseInt((limit.value || "500") as string);
+  const limitNum = parseInt(limit.value!);
   const startTimeOffsetMs =
     timeRange.value && timeRange.value !== "0"
       ? parseInt(timeRange.value as string)


### PR DESCRIPTION
## TL;DR

Adds a CloudWatch filter-pattern search box to the log stream viewer, so you can
search the events inside a single stream instead of scrolling the live tail.

## Background

The stream viewer only supported live-tailing the most recent N events. Finding a
specific message meant bumping the limit and eyeballing the list. The backend
already exposed `FilterLogEvents` via `POST /aws/logs/log-groups/:name/filter-events`,
but nothing in the stream viewer consumed it — only an unused imperative mutation
hook (`useFilterLogEvents`) existed.

## Changes

- **`useFilteredLogEvents`** (`src/frontend/hooks/useLogs.ts`) — replaces the unused
  `useFilterLogEvents` mutation with a stream-scoped `useQuery`. Sends
  `logStreamNames: [stream]` so the search never leaks across streams, recomputes
  `startTime` from a relative offset on every fetch so the window tracks "now"
  across auto-refresh ticks, and stays disabled until a group, stream, and non-empty
  pattern are all present.
- **Stream viewer** (`CloudWatchLogsDashboard.tsx`) — search input (Enter or
  Search to commit), a time-range select (5m → 24h, All time), and a Clear button.
  A committed pattern switches the pane into search mode: live-tail polling and
  auto-scroll are suspended, and results render through the existing event list.
- **Hints** — the placeholder and helper text state what Floci actually does
  (case-sensitive substring match). CloudWatch operators like `?A ?B` and
  `{ $.level = "ERROR" }` are not supported by the local implementation, so the
  copy says so rather than implying full filter-pattern syntax.
- **Empty state** — a zero-match search shows a "No events matched … widen the
  time range" message instead of an empty pane that reads as a failed load.

## Testing

`tsc --noEmit` clean. 131/131 tests pass across the two touched files, at 100%
coverage on both:

